### PR TITLE
Added customizable multiplier for SR+

### DIFF
--- a/src/Config.lua
+++ b/src/Config.lua
@@ -70,6 +70,7 @@ function M.new( db, event_bus )
     if db.auto_loot == nil then db.auto_loot = true end
     if db.handle_plus_ones == nil then db.handle_plus_ones = false end
     if db.plus_one_prompt == nil then db.plus_one_prompt = false end
+    if db.sr_plus_multiplier == nil then db.sr_plus_multiplier = 1 end
     if db.auto_loot_announce == nil then db.auto_loot_announce = true end
     if db.loot_frame_cursor == nil then db.loot_frame_cursor = false end
     if db.client_show_roll_popup == nil then db.client_show_roll_popup = "Off" end
@@ -129,6 +130,10 @@ function M.new( db, event_bus )
     info( string.format( "Roll thresholds: %s %s, %s %s%s", hl( "MS" ), ms_threshold, hl( "OS" ), os_threshold, tmog_info ) )
   end
 
+  local function print_sr_plus_multiplier()
+    info( string.format( "SR+ multiplier: %s", hl( db.sr_plus_multiplier ) ) )
+  end
+
   local function print_transmog_rolling_setting( show_threshold )
     if m.bcc then return end
     local tmog_rolling_enabled = db.tmog_rolling_enabled
@@ -149,6 +154,7 @@ function M.new( db, event_bus )
     print_default_rolling_time()
     print_master_loot_frame_rows()
     print_roll_thresholds()
+    print_sr_plus_multiplier()
     print_transmog_rolling_setting()
 
     for toggle_key, setting in pairs( toggles ) do
@@ -262,6 +268,16 @@ function M.new( db, event_bus )
     info( string.format( "Usage: %s <threshold>", hl( "/rf config os" ) ) )
   end
 
+  local function configure_sr_plus_multiplier( args )
+    for value in string.gmatch( args, "config sr%-plus%-multiplier (%d+)" ) do
+      db.sr_plus_multiplier = tonumber( value )
+      print_sr_plus_multiplier()
+      return
+    end
+
+    info( string.format( "Usage: %s <multiplier>", hl( "/rf config sr-plus-multiplier" ) ) )
+  end
+
   local function configure_tmog_threshold( args )
     if args == "config tmog" then
       db.tmog_rolling_enabled = not db.tmog_rolling_enabled
@@ -306,6 +322,9 @@ function M.new( db, event_bus )
     m.print( string.format( "%s %s - set MS rolling threshold ", rfc( "ms" ), v( "threshold" ) ) )
     m.print( string.format( "%s - show OS rolling threshold ", rfc( "os" ) ) )
     m.print( string.format( "%s %s - set OS rolling threshold ", rfc( "os" ), v( "threshold" ) ) )
+    m.print( string.format( "%s - show SR+ multiplier ", rfc( "sr-plus-multiplier" ) ) )
+    m.print( string.format( "%s %s - set SR+ multiplier ", rfc( "sr-plus-multiplier" ), v( "multiplier" ) ) )
+
 
     if m.vanilla then
       m.print( string.format( "%s - toggle TMOG rolling", rfc( "tmog" ) ) )
@@ -421,6 +440,11 @@ function M.new( db, event_bus )
       return
     end
 
+    if string.find( args, "^config sr%-plus%-multiplier" ) then
+      configure_sr_plus_multiplier( args )
+      return
+    end
+
     if string.find( args, "^config tmog" ) then
       configure_tmog_threshold( args )
       return
@@ -493,6 +517,7 @@ function M.new( db, event_bus )
     ms_roll_threshold = get( "ms_roll_threshold" ),
     on_command = on_command,
     os_roll_threshold = get( "os_roll_threshold" ),
+    sr_plus_multiplier = get( "sr_plus_multiplier" ),
     print = print,
     print_help = print_help,
     print_raid_roll_settings = printfn( "auto_raid_roll" ),

--- a/src/OptionsPopup.lua
+++ b/src/OptionsPopup.lua
@@ -330,6 +330,7 @@ function M.new( popup_builder, awarded_loot, version_broadcast, event_bus, confi
       e.create_config( "Show player roles", "show_player_roles", "checkbox", "Show player roles in rolling popup" )
       e.create_config( "MainSpec rolling threshold", "ms_roll_threshold", "number" )
       e.create_config( "OffSpec rolling threshold", "os_roll_threshold", "number" )
+      e.create_config( "SR+ multiplier", "sr_plus_multiplier", "number", "Multiplier applied to SR+ value when calculating rolls." )
       this.tmog_rolling_enabled = e.create_config( "Enable transmog rolling", "tmog_rolling_enabled", "checkbox", nil, function( value )
         if value then
           this:GetParent():GetParent().tmog_roll_threshold.input.enable()

--- a/src/RollResultAnnouncer.lua
+++ b/src/RollResultAnnouncer.lua
@@ -35,7 +35,7 @@ function M.new( chat, roll_controller, softres, config )
       local sr_player = m.find( winners[ 1 ].name, sr_players, 'name' )
 
       if sr_player and sr_player.sr_plus then
-        local plus_value = sr_player.sr_plus
+        local plus_value = sr_player.sr_plus * config.sr_plus_multiplier()
         value = value - plus_value
         return string.format( "%s+%s=%s", value, plus_value, value + plus_value )
       end

--- a/src/SoftResRollingLogic.lua
+++ b/src/SoftResRollingLogic.lua
@@ -205,7 +205,7 @@ function M.new(
     end
 
     if player.sr_plus then
-      roll = roll + player.sr_plus
+      roll = roll + (player.sr_plus * config.sr_plus_multiplier())
     end
 
     player.rolls = player.rolls - 1


### PR DESCRIPTION
A simple multiplier for SR+ values, useful for guilds that use non-standard SR+ systems. the default multiplier is 1.
Fully implemented in config, GUI and announcements:

`/rf config sr-plus-multiplier X` to change the multiplier
<img width="238" height="25" alt="image" src="https://github.com/user-attachments/assets/55d5b293-8be3-4420-b8d7-fe93c06d99d8" />

`/rf config` shows the current multiplier:
<img width="372" height="84" alt="image" src="https://github.com/user-attachments/assets/fcdda947-cd77-41f4-9e86-6161d8c5eaa5" />

Value can be changed in the settings GUI in the Rolling tab:
<img width="755" height="640" alt="image" src="https://github.com/user-attachments/assets/a87f6c32-531c-4052-9a53-a9b4e37f071e" />

Announcements also work correctly:
<img width="491" height="403" alt="image" src="https://github.com/user-attachments/assets/277b5ed4-2b4a-4981-89a8-6d6c454738cb" />

